### PR TITLE
UniPro Pull Request: Performance Fixes

### DIFF
--- a/_patch.diff
+++ b/_patch.diff
@@ -1,0 +1,331 @@
+diff --git a/pom.xml b/pom.xml
+index dbbd332..afffd1f 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -61,6 +61,11 @@
+   </build>
+   <dependencies>
+     <dependency>
++      <groupId>org.apache.commons</groupId>
++      <artifactId>commons-lang3</artifactId>
++      <version>3.5</version>
++    </dependency>
++    <dependency>
+       <groupId>org.slf4j</groupId>
+       <artifactId>slf4j-api</artifactId>
+       <version>${slf4j.version}</version>
+diff --git a/src/main/java/ru/relex/c14n2/DOMCanonicalizerHandler.java b/src/main/java/ru/relex/c14n2/DOMCanonicalizerHandler.java
+index 792811c..10beb81 100644
+--- a/src/main/java/ru/relex/c14n2/DOMCanonicalizerHandler.java
++++ b/src/main/java/ru/relex/c14n2/DOMCanonicalizerHandler.java
+@@ -16,6 +16,8 @@ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ import org.w3c.dom.Attr;
+ import org.w3c.dom.Node;
++import org.w3c.dom.NamedNodeMap;
++import org.apache.commons.lang3.StringUtils;
+ 
+ /**
+  * C14N2 canonicalizer.
+@@ -32,6 +34,11 @@ class DOMCanonicalizerHandler {
+   private static final String CF = "&#x%s;";
+   private static final String C = ":";
+ 
++  private static final byte[] XD = {'&','#','x','D',';'};
++  private static final byte[] GT = {'&','g','t',';'};
++  private static final byte[] LT = {'&','l','t',';'};
++  private static final byte[] AMP = {'&','a','m','p',';'};
++
+   private List<Node> excludeList;
+   private Parameters parameters;
+   private StringBuffer outputBuffer;
+@@ -178,7 +185,7 @@ class DOMCanonicalizerHandler {
+ 
+     output.append(">");
+ 
+-    outputBuffer.append(output);
++    StringUtils.join(outputBuffer,output);
+   }
+ 
+   /**
+@@ -207,7 +214,7 @@ class DOMCanonicalizerHandler {
+       bEnd = true;
+     }
+ 
+-    outputBuffer.append(output);
++    StringUtils.join(outputBuffer,output);
+   }
+ 
+   /**
+@@ -216,6 +223,7 @@ class DOMCanonicalizerHandler {
+    * @param node
+    *          text node
+    */
++
+   protected void processText(Node node) {
+     LOGGER.debug("processText: {}", node);
+     if (getNodeDepth(node) < 2) {
+@@ -224,15 +232,22 @@ class DOMCanonicalizerHandler {
+ 
+     String text = node.getNodeValue() != null ? node.getNodeValue() : "";
+ 
+-    text = processText(text, false);
+-
+-    StringBuffer value = new StringBuffer();
++    StringBuffer value = new StringBuffer(text.length());
+     for (int i = 0; i < text.length(); i++) {
+       char codepoint = text.charAt(i);
+-      if (codepoint == 13) {
+-        value.append(String.format(CF, Integer.toHexString(codepoint)
+-            .toUpperCase()));
+-      } else {
++      if (codepoint == '&') {
++        value.append(AMP);
++      }
++      else if (codepoint == '<') {
++        value.append(LT);
++      }
++      else if (codepoint == '>') {
++        value.append(GT);
++      }
++      else if (codepoint == 0xd) {
++        value.append(XD);
++      }
++      else {
+         value.append(codepoint);
+       }
+     }
+@@ -240,8 +255,9 @@ class DOMCanonicalizerHandler {
+ 
+     if (parameters.isTrimTextNodes()) {
+       boolean b = true;
+-      for (int ai = 0; ai < node.getParentNode().getAttributes().getLength(); ai++) {
+-        Node attr = node.getParentNode().getAttributes().item(ai);
++      NamedNodeMap attrs = node.getParentNode().getAttributes();
++      for (int ai = 0; ai < attrs.getLength(); ai++) {
++        Node attr = attrs.item(ai);
+         if (isInExcludeList(attr))
+           continue;
+         if (XML.equals(getNodePrefix(attr))
+@@ -252,7 +268,7 @@ class DOMCanonicalizerHandler {
+         }
+       }
+       if (b) {
+-        text = text.trim();
++        text = StringUtils.trim(text);
+       }
+     }
+ 
+@@ -267,7 +283,7 @@ class DOMCanonicalizerHandler {
+           for (QNameAwareParameter en : parameters.getQnameAwareElements()) {
+             if (nodeName.equals(en.getName())
+                 && en.getNs().equals(attrPrfxNcp.getUri())) {
+-              text = ncp.getNewPrefix() + text.substring(XSD.length());
++              text = StringUtils.join(ncp.getNewPrefix(), StringUtils.substring(text, XSD.length()));
+             }
+           }
+         }
+@@ -278,10 +294,10 @@ class DOMCanonicalizerHandler {
+       Node prntNode = node.getParentNode();
+       String nodeName = getLocalName(prntNode);
+       String nodePrefix = getNodePrefix(prntNode);
++      String nodeText = node.getTextContent();
+       NamespaceContextParams ncp = getLastElement(nodePrefix);
+       for (QNameAwareParameter en : parameters.getQnameAwareXPathElements()) {
+         if (nodeName.equals(en.getName()) && ncp.getUri().equals(en.getNs())) {
+-          String nodeText = node.getTextContent();
+           NSContext nsContext = xpathesNsMap.get(nodeText);
+           List<String> xpathNs = nsContext.getXpathNs();
+           StringBuffer sb = new StringBuffer(nodeText.length());
+@@ -293,9 +309,9 @@ class DOMCanonicalizerHandler {
+             for (int i = 0; i < words.size(); i++) {
+               Object obj = words.elementAt(i);
+               String word = obj.toString();
+-              int idx = nodeText.indexOf(word, baseTextIdx);
++              int idx = StringUtils.indexOf(nodeText, word, baseTextIdx);
+               if (idx != baseTextIdx) {
+-                sb.append(nodeText.substring(baseTextIdx, idx));
++                sb.append(StringUtils.substring(nodeText, baseTextIdx, idx));
+                 baseTextIdx = idx;
+               }
+               if (!(obj instanceof XString)
+@@ -306,7 +322,7 @@ class DOMCanonicalizerHandler {
+                 if (it.hasNext())
+                   ns = it.next();
+                 else {
+-                  sb.append(nodeText.substring(baseTextIdx));
++                  sb.append(StringUtils.substring(nodeText, baseTextIdx));
+                   break;
+                 }
+               } else {
+@@ -320,7 +336,7 @@ class DOMCanonicalizerHandler {
+       }
+     }
+ 
+-    outputBuffer.append(text);
++    StringUtils.join(outputBuffer,text);
+   }
+ 
+   /**
+@@ -343,7 +359,7 @@ class DOMCanonicalizerHandler {
+     if (bStart && getNodeDepth(node) == 1) {
+       output.append("\n");
+     }
+-    outputBuffer.append(output);
++    StringUtils.join(outputBuffer,output);
+   }
+ 
+   /**
+@@ -365,7 +381,8 @@ class DOMCanonicalizerHandler {
+     if (bStart && getNodeDepth(node) == 1) {
+       output.append("\n");
+     }
+-    outputBuffer.append(output);
++    StringUtils.join(outputBuffer,output);
++
+   }
+ 
+   /**
+@@ -376,7 +393,8 @@ class DOMCanonicalizerHandler {
+    */
+   protected void processCData(Node node) {
+     LOGGER.debug("processCData:" + node);
+-    outputBuffer.append(processText(node.getNodeValue(), false));
++    StringUtils.join(outputBuffer,processText(node.getNodeValue(), false));
++
+   }
+ 
+   /**
+@@ -462,20 +480,18 @@ class DOMCanonicalizerHandler {
+    *          DOM node
+    */
+   private void removeNamespaces(Node node) {
+-    for (String prefix : namespaces.keySet()) {
+-      List<NamespaceContextParams> nsLevels = namespaces.get(prefix);
+-      while (!nsLevels.isEmpty()
+-          && getLastElement(prefix).getDepth() >= getNodeDepth(node)) {
++    int nDepth = getNodeDepth(node);
++    for (Iterator<Map.Entry<String, List<NamespaceContextParams>>> it = namespaces.entrySet().iterator(); it.hasNext(); ) {
++      Map.Entry<String, List<NamespaceContextParams>> entry = it.next();
++      List<NamespaceContextParams> nsLevels = entry.getValue();
++      while (!nsLevels.isEmpty() &&
++             nsLevels.get(nsLevels.size() - 1).getDepth() >= nDepth) {
++
+         nsLevels.remove(nsLevels.size() - 1);
+       }
+-    }
+-
+-    Iterator<Entry<String, List<NamespaceContextParams>>> it = namespaces
+-        .entrySet().iterator();
+-    while (it.hasNext()) {
+-      Entry<String, List<NamespaceContextParams>> en = it.next();
+-      if (en.getValue().size() == 0)
++      if (nsLevels.isEmpty()) {
+         it.remove();
++      }
+     }
+   }
+ 
+@@ -565,6 +581,16 @@ class DOMCanonicalizerHandler {
+ 
+     List<NamespaceContextParams> outNSList = new ArrayList<NamespaceContextParams>();
+ 
++    String nPrefix = getNodePrefix(node);
++
++    String childText = null;
++    if (parameters.getQnameAwareElements().size() > 0 ||
++        (parameters.getQnameAwareXPathElements().size() > 0 &&
++      node.getChildNodes().getLength() == 1)) {
++
++      childText = node.getTextContent();
++    }
++
+     int depth = getNodeDepth(node);
+     for (String prefix : namespaces.keySet()) {
+       NamespaceContextParams ncp = getLastElement(prefix);
+@@ -577,7 +603,7 @@ class DOMCanonicalizerHandler {
+         ncp = entry;
+       }
+       if (ncp.isHasOutput() != null && !ncp.isHasOutput()) {
+-        if (isPrefixVisible(node, prefix)) {
++        if (isPrefixVisible(node, prefix, childText, nPrefix)) {
+           NamespaceContextParams entry = ncp.clone();
+           entry.setPrefix(prefix);
+           outNSList.add(entry);
+@@ -663,9 +689,9 @@ class DOMCanonicalizerHandler {
+    * @return Returns true if prefix is shown in the output of the node, false -
+    *         otherwise.
+    */
+-  private boolean isPrefixVisible(Node node, String prefix) {
+-    String nodePrefix = getNodePrefix(node);
+-    if (nodePrefix.equals(prefix)) {
++  private boolean isPrefixVisible(Node node, String prefix, String childText, String nPrefix) {
++
++    if (nPrefix.equals(prefix)) {
+       return true;
+     }
+ 
+@@ -673,10 +699,12 @@ class DOMCanonicalizerHandler {
+     if (parameters.getQnameAwareElements().size() > 0) {
+       NamespaceContextParams ncp = getLastElement(prefix);
+       String prfx = ncp.getPrefix();
+-      String childText = node.getTextContent();
++      if (childText == null) {
++        childText = node.getTextContent();
++      }
+       if (childText != null && childText.startsWith(prfx + C)
+           && node.getChildNodes().getLength() == 1) {
+-        NamespaceContextParams attrPrfxNcp = getLastElement(nodePrefix);
++        NamespaceContextParams attrPrfxNcp = getLastElement(nPrefix);
+         for (QNameAwareParameter en : parameters.getQnameAwareElements()) {
+           if (nodeLocalName.equals(en.getName())
+               && en.getNs().equals(attrPrfxNcp.getUri())) {
+@@ -687,8 +715,10 @@ class DOMCanonicalizerHandler {
+     }
+     if (parameters.getQnameAwareXPathElements().size() > 0
+         && node.getChildNodes().getLength() == 1) {
+-      NamespaceContextParams ncp = getLastElement(nodePrefix);
+-      String childText = node.getTextContent();
++      NamespaceContextParams ncp = getLastElement(nPrefix);
++      if (childText == null) {
++        childText = node.getTextContent();
++      }
+       for (QNameAwareParameter en : parameters.getQnameAwareXPathElements()) {
+         if (nodeLocalName.equals(en.getName())
+             && ncp.getUri().equals(en.getNs())) {
+@@ -749,16 +779,16 @@ class DOMCanonicalizerHandler {
+    * @return replacement text
+    */
+   private String processText(String text, boolean bAttr) {
+-    text = text.replace("&", "&amp;");
+-    text = text.replace("<", "&lt;");
++    text = StringUtils.replace(text,"&", "&amp;");
++    text = StringUtils.replace(text, "<", "&lt;");
+     if (!bAttr) {
+-      text = text.replace(">", "&gt;");
++      text = StringUtils.replace(text, ">", "&gt;");
+     } else {
+-      text = text.replace("\"", "&quot;");
+-      text = text.replace("#xA", "&#xA;");
+-      text = text.replace("#x9", "&#x9;");
++      text = StringUtils.replace(text, "\"", "&quot;");
++      text = StringUtils.replace(text, "#xA", "&#xA;");
++      text = StringUtils.replace(text, "#x9", "&#x9;");
+     }
+-    text = text.replace("#xD", "&#xD;");
++    text = StringUtils.replace(text, "#xD", "&#xD;");
+     return text;
+   }
+ 
+@@ -818,8 +848,8 @@ class DOMCanonicalizerHandler {
+       String name = node.getNodeName();
+       int idx = name.indexOf(C);
+       if (idx > -1)
+-        return name.substring(0, idx);
++        return StringUtils.substring(name,0, idx);
+     }
+     return prfx;
+   }
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
These changes provide up to 30x speedup for big XML files.

Changes:
-    Removed redundant access to nodes' text content and prefix.
-    Optimized processText function to make the transformation in a single pass and operate with char arrays instead of strings.
 -   Optimized removeNamespaces function to make the cleanup in a single pass.
 -   Replaced some string operations with StringUtils functions